### PR TITLE
Updated requirements and yaml file

### DIFF
--- a/monai_bootcamp.yml
+++ b/monai_bootcamp.yml
@@ -14,7 +14,7 @@ dependencies:
   - pillow=7.2.0
   - pip=20.2.3
   - python=3.8.5
-  - pytorch=1.6.0
+  - pytorch=1.10.1 # include +cu113 for CUDA 11.3 with newer graphics cards
   - scikit-image=0.17.2
   - scikit-learn=0.23.2
   - setuptools=49.6.0
@@ -22,4 +22,4 @@ dependencies:
   - pip:
     - monai==0.8.0
     - nibabel==3.1.1
-    - pytorch-ignite==0.3.0
+    - pytorch-ignite==0.4.7

--- a/monai_bootcamp.yml
+++ b/monai_bootcamp.yml
@@ -1,0 +1,25 @@
+
+name: monai-bootcamp
+channels:
+  - pytorch
+  - conda-forge
+  - defaults
+dependencies:
+  - ipykernel=5.3.4
+  - ipython=7.18.1
+  - jupyter=1.0.0
+  - matplotlib=3.3.2
+  - notebook=6.1.4
+  - numpy=1.19.1
+  - pillow=7.2.0
+  - pip=20.2.3
+  - python=3.8.5
+  - pytorch=1.6.0
+  - scikit-image=0.17.2
+  - scikit-learn=0.23.2
+  - setuptools=49.6.0
+  - torchvision=0.7.0
+  - pip:
+    - monai==0.8.0
+    - nibabel==3.1.1
+    - pytorch-ignite==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ monai==0.8.0
 nibabel==3.1.1
 notebook==6.1.4
 numpy==1.19.1
-pytorch-ignite==0.3.0
+pytorch-ignite==0.4.7
 scikit-image==0.17.2
 scikit-learn==.0.23.2
-torch==1.6.0
+torch==1.10.1 # include +cu113 for CUDA 11.3 with newer graphics cards
 torchvision==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+ipykernel==5.3.4
+ipython==7.18.1
+jupyter==1.0.0
+matplotlib==3.3.2
+monai==0.8.0
+nibabel==3.1.1
+notebook==6.1.4
+numpy==1.19.1
+pytorch-ignite==0.3.0
+scikit-image==0.17.2
+scikit-learn==.0.23.2
+torch==1.6.0
+torchvision==0.7.0


### PR DESCRIPTION
Dear MONAI bootcamp Team - 

This is really minor and doesn't really affect running this on colab (which is probably the most commonly used way to look through the contents here), but the requirements.txt and the yaml file to create the conda environments locally for this repo are empty. I noticed the 2020 version of the bootcamp had it filled out, and tested it locally to make sure it works. 

I also revved the versions for a couple of dependencies - pytorch-ignite, pytorch itself, and monai (to 0.8.0 - the current version). 

Please feel free to discard this if it isn't really useful - but thought I'd let you know in any case!

Happy holidays!